### PR TITLE
Fix bug in Mongo service

### DIFF
--- a/petstore/src/config/Mongo.ts
+++ b/petstore/src/config/Mongo.ts
@@ -9,7 +9,8 @@ export class Mongo {
   private url: string = config.get('mongo.url').toString();
 
   async db() {
-    if(!this.db) {
+    // ensure a single database connection is created
+    if (!this._db) {
       this._db = await MongoClient.connect(this.url);
     }
     return this._db;


### PR DESCRIPTION
## Summary
- fix bug that reused method name in mongo connection check

## Testing
- `npm test` (fails: `npm-run-all: not found`)
- `npm test` in users service (fails: `rimraf/bin.js: not found`)


------
https://chatgpt.com/codex/tasks/task_e_685bc9754528832f8700667b5abc69fc